### PR TITLE
DDCE-6670: Estates - Investigate and Fix "Kosovo" Option in Country of Nationality Dropdown

### DIFF
--- a/conf/location-autocomplete-canonical-list-cy.json
+++ b/conf/location-autocomplete-canonical-list-cy.json
@@ -1,9 +1,5 @@
 [
   [
-    "Kosovo",
-    "country:XK"
-  ],
-  [
     "Andorra",
     "country:AD"
   ],

--- a/conf/location-autocomplete-canonical-list.json
+++ b/conf/location-autocomplete-canonical-list.json
@@ -1,9 +1,5 @@
 [
   [
-    "Kosovo",
-    "country:XK"
-  ],
-  [
     "Andorra",
     "country:AD"
   ],


### PR DESCRIPTION
Dependency updates and further changes have been reverted.